### PR TITLE
Add support for Longan Nano Lite (20KB RAM, 64KB Flash)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,10 @@ default: build_longan_nano
 build_longan_nano: derzforth.asm
 	bronzebeard -c -i boards/longan_nano/ --include-definitions derzforth.asm
 
+.PHONY: build_longan_nano_lite
+build_longan_nano_lite: derzforth.asm
+	bronzebeard -c -i boards/longan_nano_lite/ --include-definitions derzforth.asm
+
 .PHONY: build_wio_lite
 build_wio_lite: derzforth.asm
 	bronzebeard -c -i boards/wio_lite/ --include-definitions derzforth.asm

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The hardware requirements for running DerzForth are minimal and straightforward:
 
 DerzForth has been tested on the following RISC-V development boards:
 * [Longan Nano](https://www.seeedstudio.com/Sipeed-Longan-Nano-RISC-V-GD32VF103CBT6-DEV-Board-p-4725.html)
+* [Longan Nano Lite](https://docs.platformio.org/en/latest/boards/gd32v/sipeed-longan-nano-lite.html)
 * [Wio Lite](https://www.seeedstudio.com/Wio-Lite-RISC-V-GD32VF103-p-4293.html)
 * [GD32 Dev Board](https://www.seeedstudio.com/SeeedStudio-GD32-RISC-V-kit-with-LCD-p-4303.html)
 * [HiFive1 Rev B](https://www.sifive.com/boards/hifive1-rev-b)

--- a/boards/longan_nano/board.asm
+++ b/boards/longan_nano/board.asm
@@ -1,4 +1,4 @@
-# include definitions related to the GigaDevice GD32VF103CBT6 chip
+# include definitions related to the GigaDevice GD32VF103 chip
 #  (the --include-definitions flag to bronzebeard puts this on the path)
 include GD32VF103.asm
 

--- a/boards/longan_nano_lite/board.asm
+++ b/boards/longan_nano_lite/board.asm
@@ -1,14 +1,14 @@
-# include definitions related to the GigaDevice GD32VF103CBT6 chip
+# include definitions related to the GigaDevice GD32VF103C8T6 chip
 #  (the --include-definitions flag to bronzebeard puts this on the path)
 include GD32VF103.asm
 
-# 32KB @ 0x20000000
+# 20KB @ 0x20000000
 RAM_BASE_ADDR = 0x20000000
-RAM_SIZE = 32 * 1024
+RAM_SIZE = 20 * 1024
 
-# 128KB @ 0x08000000
+# 64KB @ 0x08000000
 ROM_BASE_ADDR = 0x08000000
-ROM_SIZE = 128 * 1024
+ROM_SIZE = 64 * 1024
 
 # 8MHz is the default GD32VF103 clock freq
 CLOCK_FREQ = 8000000

--- a/boards/longan_nano_lite/board.asm
+++ b/boards/longan_nano_lite/board.asm
@@ -1,4 +1,4 @@
-# include definitions related to the GigaDevice GD32VF103C8T6 chip
+# include definitions related to the GigaDevice GD32VF103 chip
 #  (the --include-definitions flag to bronzebeard puts this on the path)
 include GD32VF103.asm
 


### PR DESCRIPTION
There's another board floating around which is the _**"Lite"**_ longan nano. It has RAM limited to 20KB and Flash limited to 64KB.

The MCU is GD32VF103C**8**T6 instead of GD32VF103C**B**T6. I have both models and often find myself switching between them during testing. This should make it easier.

Let me know if I missed something.