### PR TITLE
Remove unnecessary instruction by adjusting data stack ptr decrement

### DIFF
--- a/derzforth.asm
+++ b/derzforth.asm
@@ -461,8 +461,8 @@ code_ex:
     dw %position(body_ex, RAM_BASE_ADDR)
 body_ex:
     addi DSP, DSP, -8  # dec data stack ptr
-    lw t0, 0(DSP)      # pop addr into t0
-    lw t1, 4(DSP)      # pop value into t1
+    lw t0, 4(DSP)      # pop addr into t0
+    lw t1, 0(DSP)      # pop value into t1
     sw t1, 0(t0)       # store value at addr
     j next
 
@@ -517,8 +517,8 @@ code_plus:
     dw %position(body_plus, RAM_BASE_ADDR)
 body_plus:
     addi DSP, DSP, -8  # dec data stack ptr
-    lw t0, 0(DSP)      # pop first value into t0
-    lw t1, 4(DSP)      # pop second value into t1
+    lw t0, 4(DSP)      # pop first value into t0
+    lw t1, 0(DSP)      # pop second value into t1
     add t0, t0, t1     # ADD the values together into t0
     sw t0, 0(DSP)      # push value onto stack
     addi DSP, DSP, 4   # inc data stack ptr
@@ -532,8 +532,8 @@ code_nand:
     dw %position(body_nand, RAM_BASE_ADDR)
 body_nand:
     addi DSP, DSP, -8  # dec data stack ptr
-    lw t0, 0(DSP)      # pop first value into t0
-    lw t1, 4(DSP)      # pop second value into t1
+    lw t0, 4(DSP)      # pop first value into t0
+    lw t1, 0(DSP)      # pop second value into t1
     and t0, t0, t1     # AND the values together into t0
     not t0, t0         # NOT t0 (invert the bits)
     sw t0, 0(DSP)      # push value onto stack


### PR DESCRIPTION
This is not a big change, but it essentially removes one `addi` instruction in the `!`, `+`, and `nand` words by moving the stack pointer down by 8 instead of 4.