### PR TITLE
Handle the F_HIDDEN flag when defining a new word

### DIFF
--- a/derzforth.asm
+++ b/derzforth.asm
@@ -162,8 +162,8 @@ lookup:
 
     # skip if the word is hidden
     li t1, F_HIDDEN            # load hidden flag into t1
-    and t2, t0, t1             # isolate hidden bit in word hash
-    bnez t2, lookup_next       # if hidden, skip this word and try the next one
+    and t1, t0, t1             # isolate hidden bit in word hash
+    bnez t1, lookup_next       # if hidden, skip this word and try the next one
 
     li t1, ~FLAGS_MASK         # t1 = inverted FLAGS_MASK
     and t0, t0, t1             # ignore flags when comparing hashes


### PR DESCRIPTION
Hi,

This PR adds the ability to hide a word while it's being defined in `body_colon`. It also skips the word in `lookup` if it has the `F_HIDDEN` flag set to 1, and it _should_ clear the flag in `body_semi` however...

I've tried to handle the `F_HIDDEN` flag similarly to _sectorforth_ and _jonesforth_ but I can't seem to figure out how to clear the flag once it's set.

I was hoping you could help debug the `# remove the hidden flag` section of `body_semi`, so I opened the PR a bit prematurely.

Thanks