### PR TITLE
Dont use 'tp' and 'gp' registers

### DIFF
--- a/boards/gd32_dev_board/board.asm
+++ b/boards/gd32_dev_board/board.asm
@@ -50,7 +50,7 @@ gpio_config_done:
 # Arg: a0 = baud rate
 serial_init:
     # save return addr (since serial_init calls other funcs)
-    mv s8, ra
+    mv SAVED0, ra
 
     # setup RCU base addr in t0
     li t0, RCU_BASE_ADDR
@@ -85,7 +85,7 @@ serial_init:
 
 serial_init_done:
     # restore return addr and return
-    mv ra, s8
+    mv ra, SAVED0
     ret
 
 

--- a/boards/longan_nano/board.asm
+++ b/boards/longan_nano/board.asm
@@ -50,7 +50,7 @@ gpio_config_done:
 # Arg: a0 = baud rate
 serial_init:
     # save return addr (since serial_init calls other funcs)
-    mv s8, ra
+    mv SAVED0, ra
 
     # setup RCU base addr in t0
     li t0, RCU_BASE_ADDR
@@ -85,7 +85,7 @@ serial_init:
 
 serial_init_done:
     # restore return addr and return
-    mv ra, s8
+    mv ra, SAVED0
     ret
 
 

--- a/boards/longan_nano_lite/board.asm
+++ b/boards/longan_nano_lite/board.asm
@@ -50,7 +50,7 @@ gpio_config_done:
 # Arg: a0 = baud rate
 serial_init:
     # save return addr (since serial_init calls other funcs)
-    mv s8, ra
+    mv SAVED0, ra
 
     # setup RCU base addr in t0
     li t0, RCU_BASE_ADDR
@@ -85,7 +85,7 @@ serial_init:
 
 serial_init_done:
     # restore return addr and return
-    mv ra, s8
+    mv ra, SAVED0
     ret
 
 

--- a/boards/wio_lite/board.asm
+++ b/boards/wio_lite/board.asm
@@ -50,7 +50,7 @@ gpio_config_done:
 # Arg: a0 = baud rate
 serial_init:
     # save return addr (since serial_init calls other funcs)
-    mv s8, ra
+    mv SAVED0, ra
 
     # setup RCU base addr in t0
     li t0, RCU_BASE_ADDR
@@ -85,7 +85,7 @@ serial_init:
 
 serial_init_done:
     # restore return addr and return
-    mv ra, s8
+    mv ra, SAVED0
     ret
 
 

--- a/derzforth.asm
+++ b/derzforth.asm
@@ -62,25 +62,23 @@ F_HIDDEN    = 0x40000000
 
 # "The Classical Forth Registers"
 W   = s0  # working register
-IP  = gp  # interpreter pointer
+IP  = s1  # interpreter pointer
 DSP = sp  # data stack pointer
-RSP = tp  # return stack pointer
+RSP = s2  # return stack pointer
 
 # variable registers
-STATE  = s1  # 0 = execute, 1 = compile
-TIB    = s2  # text input buffer addr
-TBUF   = s3  # text buffer addr
-TLEN   = s4  # text buffer length
-TPOS   = s5  # text buffer current position
-HERE   = s6  # next dict entry addr
-LATEST = s7  # latest dict entry addr
+STATE  = s3  # 0 = execute, 1 = compile
+TIB    = s4  # text input buffer addr
+TBUF   = s5  # text buffer addr
+TLEN   = s6  # text buffer length
+TPOS   = s7  # text buffer current position
+HERE   = s8  # next dict entry addr
+LATEST = s9  # latest dict entry addr
 
 # extra saved regs (use for whatever)
 # use one of these for heap size tracking?
-SAVED0 = s8
-SAVED1 = s9
-SAVED2 = s10
-SAVED3 = s11
+SAVED0 = s10
+SAVED1 = s11
 
 
 # Func: memclr
@@ -530,13 +528,13 @@ body_nand:
     addi DSP, DSP, 4   # inc data stack ptr
     j next
 
-#STATE  = s1  # 0 = execute, 1 = compile
-#TIB    = s2  # text input buffer addr
-#TBUF   = s3  # text buffer addr
-#TLEN   = s4  # text buffer length
-#TPOS   = s5  # text buffer current position
-#HERE   = s6  # next dict entry addr
-#LATEST = s7  # latest dict entry addr
+#STATE  = s3  # 0 = execute, 1 = compile
+#TIB    = s4  # text input buffer addr
+#TBUF   = s5  # text buffer addr
+#TLEN   = s6  # text buffer length
+#TPOS   = s7  # text buffer current position
+#HERE   = s8  # next dict entry addr
+#LATEST = s9  # latest dict entry addr
 
 align 4
 word_state:


### PR DESCRIPTION
This PR changes register assignments for `IP` and `RSP` to point to `s1` and `s2` respectively, and changes the saved register assignments for the remaining variable registers (`STATE, TIB, etc..`).

According to the [RISC-V ABI calling convention](https://github.com/riscv-non-isa/riscv-elf-psabi-doc/blob/master/riscv-cc.adoc), registers `gp (x3)` and `tp (x4)` should not be used.

I also found the use of `s8` in the board files, and changed those to `SAVED0` which now points to `s10` instead.

We lose two "extra" saved registers with this change, but that probably doesn't matter unless more complex Assembly code is to be written.