### PR TITLE
Perform bounds check on TBUF to prevent 1KB buffer from overflowing

### DIFF
--- a/derzforth.asm
+++ b/derzforth.asm
@@ -303,7 +303,7 @@ interpreter_skip_comment:
 interpreter_repl_char:
     add t0, TBUF, TLEN   # t0 = dest addr for this char in TBUF
     li t1, TIB_SIZE      # t1 = buffer size
-    bgeu TLEN, t1, error # bounds check on TBUF
+    bge TLEN, t1, error  # bounds check on TBUF
     sb a0, 0(t0)         # write char into TBUF
     addi TLEN, TLEN, 1   # TLEN += 1
     addi t0, zero, '\n'  # t0 = newline char


### PR DESCRIPTION
As the title suggests, this PR adds bounds check on `TBUF` to ensure it doesn't overflow.

I tested this by changing `TIB_SIZE` to `0x0002` and confirmed only 2 characters can be added to the buffer. After typing the third character, an error is returned.