### PR TITLE
Made compatible with RV32I core.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # DerzForth
-Bare-metal Forth implementation for RISC-V
+Bare-metal Forth implementation for RISC-V RV32I core.
 
 ## About
 Forth was initially designed and created by [Charles Moore](https://en.wikipedia.org/wiki/Charles_H._Moore).

--- a/derzforth.asm
+++ b/derzforth.asm
@@ -185,11 +185,11 @@ lookup_not_found:
 # Ret: a0 = hash value
 djb2_hash:
     li t0, 5381         # t0 = hash value
-    li t1, 33           # t1 = multiplier
 djb2_hash_loop:
     beqz a1, djb2_hash_done
     lbu t2, 0(a0)       # c <- [addr]
-    mul t0, t0, t1      # h = h * 33
+    slli t1, t0, 5      # t1 = h * 32
+    add t0, t1, t0      # h = t1 + h, so h = h * 33
     add t0, t0, t2      # h = h + c
     addi a0, a0, 1      # addr += 1
     addi a1, a1, -1     # size -= 1


### PR DESCRIPTION
Hi! I stumbled upon your awesome code while implementing my own simplest riscv rv32i core in verilog/fpga. the only thing that prevented me was the mul instruction (since rv32i does not have multiplication) when calculating the djb2 hash, so I replaced it with a left shift and add. this means an overhead of a single instruction, so hopefully shouldn't affect performance that much :) obviously this is a non-critical issue, since AFAIK almost all cores in the wild support multiplication, but I think is in line with your "from scratch" ethos! also made a little addition to README to reflect this.